### PR TITLE
Added the #unregisterEventListener() [METHODS DEPRECATED]

### DIFF
--- a/minecraft/me/wavelength/baseclient/command/CommandManager.java
+++ b/minecraft/me/wavelength/baseclient/command/CommandManager.java
@@ -35,7 +35,7 @@ public class CommandManager extends EventListener {
 
 		this.mc = Minecraft.getMinecraft();
 
-		BaseClient.instance.getEventManager().registerEvent(this);
+		BaseClient.instance.getEventManager().registerListener(this);
 	}
 
 	public String getTrigger() {

--- a/minecraft/me/wavelength/baseclient/event/EventManager.java
+++ b/minecraft/me/wavelength/baseclient/event/EventManager.java
@@ -23,14 +23,48 @@ public class EventManager {
 	public EventManager() {
 		this.eventListeners = new ArrayList<EventListener>();
 	}
-
+	
+	/**
+	 * @deprecated this method will be removed soon. Use the new {@link #registerListener(EventListener)}
+	 */
+	@Deprecated
 	public void registerEvent(EventListener eventListener) {
-		this.eventListeners.add(eventListener);
+		registerListener(eventListener);
+	}
+	
+	/**
+	 * @deprecated this method will be removed soon. Use the new {@link #unregisterListener(EventListener)}
+	 */
+	@Deprecated
+	public void unregisterEvent(EventListener eventListener) {
+		unregisterListener(eventListener);
 	}
 
-	public void unregisterEvent(EventListener eventListener) {
+	public void registerListener(EventListener eventListener) {
+		this.eventListeners.add(eventListener);
+	}
+	
+	/**
+	 * This way you can unregister an event listener from the INSTANCE.
+	 * 
+	 * NOTE: there is only one small drawback, you need to have the class's instance.
+	 * Or if you are unregistering the listener from within the listener's class, you can just do {@link #unregisterEventListener()} with "this" as parameter
+	 * 
+	 * @param clasz the listener's class
+	 */
+	public void unregisterListener(EventListener eventListener) {
 		if (eventListeners.contains(eventListener))
 			eventListeners.remove(eventListener);
+	}
+	
+	/**
+	 * This way you can unregister an event listener from the class (NOTE: doing this will unregister ALL of the instances of a class)
+	 * @param clasz the listener's class
+	 */
+	public void unregisterListener(Class<? extends EventListener> clasz) {
+		for(int i = 0; i < eventListeners.size(); i++)
+			if(eventListeners.get(i).getClass().equals(clasz))
+				eventListeners.remove(i);
 	}
 
 	public Event call(Event event) {

--- a/minecraft/me/wavelength/baseclient/module/Module.java
+++ b/minecraft/me/wavelength/baseclient/module/Module.java
@@ -91,10 +91,10 @@ public class Module extends EventListener {
 	public void setToggled(boolean toggled) {
 		this.toggled = toggled;
 		if (toggled) {
-			BaseClient.instance.getEventManager().registerEvent(this);
+			BaseClient.instance.getEventManager().registerListener(this);
 			onEnable();
 		} else {
-			BaseClient.instance.getEventManager().unregisterEvent(this);
+			BaseClient.instance.getEventManager().unregisterListener(this);
 			onDisable();
 		}
 	}

--- a/minecraft/me/wavelength/baseclient/module/ModuleManager.java
+++ b/minecraft/me/wavelength/baseclient/module/ModuleManager.java
@@ -18,7 +18,7 @@ public class ModuleManager extends EventListener {
 
 	public ModuleManager() {
 		this.modules = new ArrayList<Module>();
-		BaseClient.instance.getEventManager().registerEvent(this);
+		BaseClient.instance.getEventManager().registerListener(this);
 
 		registerModules();
 	}

--- a/minecraft/me/wavelength/baseclient/overlay/HotbarOverlay.java
+++ b/minecraft/me/wavelength/baseclient/overlay/HotbarOverlay.java
@@ -13,7 +13,7 @@ import net.minecraft.client.Minecraft;
 public class HotbarOverlay extends EventListener {
 
 	public HotbarOverlay() {
-		BaseClient.instance.getEventManager().registerEvent(this);
+		BaseClient.instance.getEventManager().registerListener(this);
 	}
 
 	@Override

--- a/minecraft/me/wavelength/baseclient/overlay/TabGui1.java
+++ b/minecraft/me/wavelength/baseclient/overlay/TabGui1.java
@@ -43,7 +43,7 @@ public class TabGui1 extends EventListener {
 	private ModuleManager moduleManager;
 
 	public TabGui1() {
-		BaseClient.instance.getEventManager().registerEvent(this);
+		BaseClient.instance.getEventManager().registerListener(this);
 
 		this.moduleManager = BaseClient.instance.getModuleManager();
 	}

--- a/minecraft/me/wavelength/baseclient/overlay/ToggledModules.java
+++ b/minecraft/me/wavelength/baseclient/overlay/ToggledModules.java
@@ -17,7 +17,7 @@ import net.minecraft.client.gui.FontRenderer;
 public class ToggledModules extends EventListener {
 
 	public ToggledModules() {
-		BaseClient.instance.getEventManager().registerEvent(this);
+		BaseClient.instance.getEventManager().registerListener(this);
 	}
 
 	@Override


### PR DESCRIPTION
Changes to the EventManager:
\+ Created two twins of the #registerEvent() and #unregisterEvent() called #registerListener() and #unregisterListener() respectively. The old methods will be deprecated and eventually removed. So please, update your code.
\+ Added the #unregisterEventListener(Class<? extends EventListener> class) method, for more information about it read the Javadoc.

Every other change is done to adapt to the new methods in the other classes.